### PR TITLE
feat: add pagination, sorting, and field selection to ListRecords

### DIFF
--- a/docs/api-reference/records.mdx
+++ b/docs/api-reference/records.mdx
@@ -56,7 +56,7 @@ curl -X POST http://localhost:8080/api/v1/databases/mydb/tables/users/records \
 
 ## List Records
 
-Get all records from a table with optional filtering.
+Get records from a table with optional filtering, pagination, sorting, and field selection.
 
 **Endpoint:** `GET /api/v1/databases/:db_name/tables/:table_name/records`
 
@@ -68,13 +68,40 @@ Get all records from a table with optional filtering.
   Table name
 </ParamField>
 
-<ParamField query="column" type="string">
-  Filter by column value. Use format `?column=value`
-</ParamField>
+### Query Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | integer | 100 | Maximum records to return (1-1000) |
+| `offset` | integer | 0 | Number of records to skip |
+| `sort` | string | `id` | Column name to sort by |
+| `order` | string | `asc` | Sort direction: `asc` or `desc` |
+| `fields` | string | (all) | Comma-separated list of columns to return |
+| `{column}` | string | - | Filter by column value (e.g., `?name=John`) |
 
 <RequestExample>
 ```bash cURL (All records)
 curl http://localhost:8080/api/v1/databases/mydb/tables/users/records \
+  -H "Authorization: Bearer <your-jwt-token>"
+```
+
+```bash cURL (Paginated)
+curl "http://localhost:8080/api/v1/databases/mydb/tables/users/records?limit=10&offset=20" \
+  -H "Authorization: Bearer <your-jwt-token>"
+```
+
+```bash cURL (Sorted)
+curl "http://localhost:8080/api/v1/databases/mydb/tables/users/records?sort=name&order=desc" \
+  -H "Authorization: Bearer <your-jwt-token>"
+```
+
+```bash cURL (Field Selection)
+curl "http://localhost:8080/api/v1/databases/mydb/tables/users/records?fields=id,name,email" \
+  -H "Authorization: Bearer <your-jwt-token>"
+```
+
+```bash cURL (Combined)
+curl "http://localhost:8080/api/v1/databases/mydb/tables/users/records?limit=10&sort=created_at&order=desc&fields=id,name" \
   -H "Authorization: Bearer <your-jwt-token>"
 ```
 
@@ -102,10 +129,25 @@ curl "http://localhost:8080/api/v1/databases/mydb/tables/users/records?name=John
       "age": 25,
       "balance": 250.00
     }
-  ]
+  ],
+  "pagination": {
+    "total": 100,
+    "limit": 10,
+    "offset": 0
+  }
+}
+```
+
+```json 400 Bad Request
+{
+  "error": "invalid 'limit' parameter: maximum is 1000"
 }
 ```
 </ResponseExample>
+
+<Note>
+  The `pagination.total` field contains the total count of records matching your filters, useful for calculating total pages.
+</Note>
 
 ---
 

--- a/internal/core/query_params.go
+++ b/internal/core/query_params.go
@@ -1,0 +1,122 @@
+// internal/core/query_params.go
+package core
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Default and limit constants for pagination
+const (
+	DefaultLimit = 100
+	MaxLimit     = 1000
+	DefaultOrder = "asc"
+)
+
+// ReservedParams contains query parameter names reserved for pagination, sorting, and field selection.
+// These should not be treated as column filters.
+var ReservedParams = map[string]bool{
+	"limit":  true,
+	"offset": true,
+	"sort":   true,
+	"order":  true,
+	"fields": true,
+}
+
+// ListQueryOptions holds parsed query parameters for ListRecords
+type ListQueryOptions struct {
+	// Pagination
+	Limit  int
+	Offset int
+
+	// Sorting
+	SortBy    string
+	SortOrder string // "asc" or "desc"
+
+	// Field Selection
+	Fields []string // Columns to return (empty = all columns)
+}
+
+// ParseListQueryOptions extracts pagination, sorting, and field selection options from query parameters.
+// Returns the parsed options and any validation error.
+func ParseListQueryOptions(queryParams url.Values) (*ListQueryOptions, error) {
+	opts := &ListQueryOptions{
+		Limit:     DefaultLimit,
+		Offset:    0,
+		SortBy:    "",
+		SortOrder: DefaultOrder,
+		Fields:    nil,
+	}
+
+	// Parse limit
+	if limitStr := queryParams.Get("limit"); limitStr != "" {
+		limit, err := strconv.Atoi(limitStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid 'limit' parameter: must be an integer")
+		}
+		if limit < 1 {
+			return nil, fmt.Errorf("invalid 'limit' parameter: must be at least 1")
+		}
+		if limit > MaxLimit {
+			return nil, fmt.Errorf("invalid 'limit' parameter: maximum is %d", MaxLimit)
+		}
+		opts.Limit = limit
+	}
+
+	// Parse offset
+	if offsetStr := queryParams.Get("offset"); offsetStr != "" {
+		offset, err := strconv.Atoi(offsetStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid 'offset' parameter: must be an integer")
+		}
+		if offset < 0 {
+			return nil, fmt.Errorf("invalid 'offset' parameter: must be non-negative")
+		}
+		opts.Offset = offset
+	}
+
+	// Parse sort column
+	if sortBy := queryParams.Get("sort"); sortBy != "" {
+		if !IsValidIdentifier(sortBy) {
+			return nil, fmt.Errorf("invalid 'sort' parameter: '%s' is not a valid column name", sortBy)
+		}
+		opts.SortBy = sortBy
+	}
+
+	// Parse sort order
+	if order := queryParams.Get("order"); order != "" {
+		lowerOrder := strings.ToLower(order)
+		if lowerOrder != "asc" && lowerOrder != "desc" {
+			return nil, fmt.Errorf("invalid 'order' parameter: must be 'asc' or 'desc'")
+		}
+		opts.SortOrder = lowerOrder
+	}
+
+	// Parse fields
+	if fieldsStr := queryParams.Get("fields"); fieldsStr != "" {
+		fields := strings.Split(fieldsStr, ",")
+		validFields := make([]string, 0, len(fields))
+		for _, field := range fields {
+			field = strings.TrimSpace(field)
+			if field == "" {
+				continue
+			}
+			if !IsValidIdentifier(field) {
+				return nil, fmt.Errorf("invalid 'fields' parameter: '%s' is not a valid column name", field)
+			}
+			validFields = append(validFields, field)
+		}
+		if len(validFields) > 0 {
+			opts.Fields = validFields
+		}
+	}
+
+	return opts, nil
+}
+
+// IsReservedParam checks if a query parameter name is reserved for pagination/sorting/fields.
+func IsReservedParam(key string) bool {
+	return ReservedParams[strings.ToLower(key)]
+}

--- a/internal/storage/user_database_storage.go
+++ b/internal/storage/user_database_storage.go
@@ -366,7 +366,7 @@ func ListRecords(ctx context.Context, userDB *sql.DB, tableName string, queryPar
 	// Add ORDER BY clause
 	if opts.SortBy != "" {
 		orderDirection := "ASC"
-		if strings.ToLower(opts.SortOrder) == "desc" {
+		if strings.EqualFold(opts.SortOrder, "desc") {
 			orderDirection = "DESC"
 		}
 		selectSQL += fmt.Sprintf(" ORDER BY %s %s", opts.SortBy, orderDirection)

--- a/internal/storage/user_database_storage.go
+++ b/internal/storage/user_database_storage.go
@@ -24,7 +24,22 @@ var (
 	ErrTypeMismatch        = errors.New("datatype mismatch")                 // Derived
 	ErrConstraintViolation = errors.New("constraint violation")              // Derived
 	ErrInvalidFilterValue  = errors.New("invalid value provided for filter") // New error
+	ErrInvalidSortColumn   = errors.New("invalid sort column")
+	ErrInvalidFieldColumn  = errors.New("invalid field column")
 )
+
+// ListRecordsResult contains records and pagination metadata
+type ListRecordsResult struct {
+	Records    []map[string]any `json:"records"`
+	Pagination PaginationMeta   `json:"pagination"`
+}
+
+// PaginationMeta contains pagination information
+type PaginationMeta struct {
+	Total  int `json:"total"`
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+}
 
 // --- User DB Connection ---
 
@@ -231,30 +246,57 @@ func InsertRecord(ctx context.Context, userDB *sql.DB, insertSQL string, values 
 	return lastID, nil
 }
 
-// Accepts tableName and query parameters directly.
-func ListRecords(ctx context.Context, userDB *sql.DB, tableName string, queryParams url.Values) ([]map[string]any, error) {
+// ListRecords retrieves records with support for filtering, pagination, sorting, and field selection.
+// Accepts tableName, query parameters, and parsed query options.
+func ListRecords(ctx context.Context, userDB *sql.DB, tableName string, queryParams url.Values, opts *core.ListQueryOptions) (*ListRecordsResult, error) {
 
-	// 1. Fetch schema to validate filter keys and convert values
+	// 1. Fetch schema to validate filter keys, sort column, and field columns
 	columnTypes, err := PragmaTableInfo(ctx, userDB, tableName)
 	if err != nil {
 		return nil, err // Propagate ErrTableNotFound or other schema errors
 	}
 
-	// 2. Build WHERE clause and arguments from queryParams
+	// 2. Validate sort column exists in schema (if specified)
+	if opts.SortBy != "" {
+		if _, exists := columnTypes[strings.ToLower(opts.SortBy)]; !exists {
+			return nil, fmt.Errorf("%w: '%s' not found in table schema", ErrInvalidSortColumn, opts.SortBy)
+		}
+	}
+
+	// 3. Validate and build field list for SELECT
+	var selectFields string
+	if len(opts.Fields) > 0 {
+		validatedFields := make([]string, 0, len(opts.Fields))
+		for _, field := range opts.Fields {
+			if _, exists := columnTypes[strings.ToLower(field)]; !exists {
+				return nil, fmt.Errorf("%w: '%s' not found in table schema", ErrInvalidFieldColumn, field)
+			}
+			validatedFields = append(validatedFields, field)
+		}
+		selectFields = strings.Join(validatedFields, ", ")
+	} else {
+		selectFields = "*"
+	}
+
+	// 4. Build WHERE clause and arguments from queryParams (excluding reserved params)
 	whereClauses := []string{}
 	args := []any{}
 
 	for key, values := range queryParams {
-		if len(values) == 0 { // Should not happen with url.Values but check anyway
+		// Skip reserved parameters
+		if core.IsReservedParam(key) {
 			continue
 		}
-		filterValueStr := values[0] // Use only the first value for simple equality filter
+
+		if len(values) == 0 {
+			continue
+		}
+		filterValueStr := values[0]
 		lowerKey := strings.ToLower(key)
 
 		// A. Validate filter key format
 		if !core.IsValidIdentifier(key) {
 			customLog.Warnf("Storage: ListRecords received invalid filter key format: %s", key)
-			// *** CHANGED: Return error instead of ignoring ***
 			return nil, fmt.Errorf("%w: invalid filter key format '%s'", ErrInvalidFilterValue, key)
 		}
 
@@ -262,28 +304,20 @@ func ListRecords(ctx context.Context, userDB *sql.DB, tableName string, queryPar
 		expectedType, exists := columnTypes[lowerKey]
 		if !exists {
 			customLog.Warnf("Storage: ListRecords received filter key not in schema: %s", key)
-			// *** CHANGED: Return error instead of ignoring ***
 			return nil, fmt.Errorf("%w: filter key '%s' not found in table schema", ErrInvalidFilterValue, key)
 		}
 
-		// C. Attempt to convert filterValueStr to expected type (logic remains same)
+		// C. Attempt to convert filterValueStr to expected type
 		var convertedValue interface{}
 		var conversionError error
 
 		switch expectedType {
-		case "INTEGER", "BOOLEAN": // Treat boolean as integer for filtering
-			// Try parsing as int first
+		case "INTEGER", "BOOLEAN":
 			if vInt, err := strconv.ParseInt(filterValueStr, 10, 64); err == nil {
 				convertedValue = vInt
 			} else {
-				// Try parsing as bool (true/false -> 1/0) if original type was BOOLEAN
-				// (Note: columnTypes stores normalized types like INTEGER, need original schema maybe?)
-				// Let's keep it simple: if it's not a valid int, error out for INTEGER/BOOLEAN filter
 				conversionError = fmt.Errorf("expected an integer for column '%s'", key)
 			}
-			// If handling actual boolean input:
-			// else if expectedType == "BOOLEAN" { ... parse "true"/"false" ... }
-
 		case "REAL":
 			if vFloat, err := strconv.ParseFloat(filterValueStr, 64); err == nil {
 				convertedValue = vFloat
@@ -291,54 +325,78 @@ func ListRecords(ctx context.Context, userDB *sql.DB, tableName string, queryPar
 				conversionError = fmt.Errorf("expected a number (float) for column '%s'", key)
 			}
 		case "TEXT":
-			convertedValue = filterValueStr // Keep as string
+			convertedValue = filterValueStr
 		case "BLOB":
-			// Cannot reliably filter BLOBs with simple equality from URL param
 			customLog.Printf("Storage: ListRecords ignoring filter on BLOB column: %s", key)
-			continue // Skip BLOB filtering
+			continue
 		default:
 			customLog.Printf("Storage: ListRecords ignoring filter on column '%s' with unhandled type '%s'", key, expectedType)
-			continue // Skip unknown types
+			continue
 		}
 
 		if conversionError != nil {
 			customLog.Printf("Storage: ListRecords conversion error for key '%s', value '%s': %v", key, filterValueStr, conversionError)
-			return nil, fmt.Errorf("%w: %s", ErrInvalidFilterValue, conversionError.Error()) // Return specific error
+			return nil, fmt.Errorf("%w: %s", ErrInvalidFilterValue, conversionError.Error())
 		}
 
-		// C. Add to WHERE clause and arguments
-		// Use original key case from query param for the SQL column name for clarity
 		whereClauses = append(whereClauses, fmt.Sprintf("%s = ?", key))
 		args = append(args, convertedValue)
-
-	} // End loop over queryParams
-
-	// 3. Construct final SQL
-	// nolint:gosec // tableName is validated by handler before reaching here
-	selectSQL := fmt.Sprintf("SELECT * FROM %s", tableName)
-	if len(whereClauses) > 0 {
-		selectSQL += " WHERE " + strings.Join(whereClauses, " AND ")
 	}
-	selectSQL += ";" // End statement
+
+	// 5. Build WHERE clause string
+	whereClause := ""
+	if len(whereClauses) > 0 {
+		whereClause = " WHERE " + strings.Join(whereClauses, " AND ")
+	}
+
+	// 6. Get total count for pagination metadata
+	// nolint:gosec // tableName is validated by handler before reaching here
+	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM %s%s", tableName, whereClause)
+	var totalCount int
+	err = userDB.QueryRowContext(ctx, countSQL, args...).Scan(&totalCount)
+	if err != nil {
+		customLog.Warnf("Storage: Failed COUNT query: %v\nSQL: %s", err, countSQL)
+		return nil, fmt.Errorf("database error counting records: %w", err)
+	}
+
+	// 7. Construct final SELECT SQL with ORDER BY and LIMIT/OFFSET
+	// nolint:gosec // tableName and selectFields are validated
+	selectSQL := fmt.Sprintf("SELECT %s FROM %s%s", selectFields, tableName, whereClause)
+
+	// Add ORDER BY clause
+	if opts.SortBy != "" {
+		orderDirection := "ASC"
+		if strings.ToLower(opts.SortOrder) == "desc" {
+			orderDirection = "DESC"
+		}
+		selectSQL += fmt.Sprintf(" ORDER BY %s %s", opts.SortBy, orderDirection)
+	} else {
+		// Default sort by id if exists, otherwise no default sort
+		if _, hasID := columnTypes["id"]; hasID {
+			selectSQL += " ORDER BY id ASC"
+		}
+	}
+
+	// Add LIMIT and OFFSET
+	selectSQL += fmt.Sprintf(" LIMIT %d OFFSET %d", opts.Limit, opts.Offset)
 
 	customLog.Printf("Storage: Executing List Records SQL: %s | Args: %v", selectSQL, args)
 
-	// 4. Execute query
+	// 8. Execute query
 	rows, err := userDB.QueryContext(ctx, selectSQL, args...)
 	if err != nil {
-		customLog.Warnf("Storage: Failed filtered SELECT *: %v\nSQL: %s", err, selectSQL)
-		// No need to check "no such table" here, PragmaTableInfo already did
+		customLog.Warnf("Storage: Failed SELECT: %v\nSQL: %s", err, selectSQL)
 		return nil, fmt.Errorf("database error listing records: %w", err)
 	}
 	defer rows.Close()
 
-	// 5. Process results (same as before)
+	// 9. Process results
 	columns, err := rows.Columns()
-	if err != nil { /* ... handle error ... */
+	if err != nil {
 		return nil, fmt.Errorf("failed processing results: %w", err)
 	}
 	numColumns := len(columns)
-	results := make([]map[string]interface{}, 0)
+	records := make([]map[string]interface{}, 0)
 
 	for rows.Next() {
 		scanArgs := make([]interface{}, numColumns)
@@ -346,7 +404,7 @@ func ListRecords(ctx context.Context, userDB *sql.DB, tableName string, queryPar
 		for i := range values {
 			scanArgs[i] = &values[i]
 		}
-		if err := rows.Scan(scanArgs...); err != nil { /* ... handle scan error ... */
+		if err := rows.Scan(scanArgs...); err != nil {
 			return nil, fmt.Errorf("failed reading record data: %w", err)
 		}
 
@@ -359,13 +417,20 @@ func ListRecords(ctx context.Context, userDB *sql.DB, tableName string, queryPar
 				rowData[colName] = rawValue
 			}
 		}
-		results = append(results, rowData)
+		records = append(records, rowData)
 	}
-	if err = rows.Err(); err != nil { /* ... handle iteration error ... */
+	if err = rows.Err(); err != nil {
 		return nil, fmt.Errorf("failed processing all records: %w", err)
 	}
 
-	return results, nil
+	return &ListRecordsResult{
+		Records: records,
+		Pagination: PaginationMeta{
+			Total:  totalCount,
+			Limit:  opts.Limit,
+			Offset: opts.Offset,
+		},
+	}, nil
 }
 
 // GetRecord executes SELECT * WHERE id = ? and returns a single map or ErrRecordNotFound.


### PR DESCRIPTION
- Add internal/core/query_params.go with ParseListQueryOptions for parsing limit, offset, sort, order, and fields query parameters
- Update storage.ListRecords to accept query options and return ListRecordsResult with pagination metadata (total, limit, offset)
- Update handlers.ListRecords to parse query options and handle new errors
- Update docs/api-reference/records.mdx with new query parameter documentation

Query parameters:
- limit: Max records to return (1-1000, default: 100)
- offset: Records to skip (default: 0)
- sort: Column to sort by
- order: Sort direction (asc/desc, default: asc)
- fields: Comma-separated columns to return

Breaking change: ListRecords response now wrapped in object with 'records' and 'pagination' fields instead of returning array directly.